### PR TITLE
Ethan/zip code endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 5. In the .env file set `ENV` to "dev"
 6. Start the app using `npm run dev`
 
+## Tests
+- Run tests using the command `npx jest`
+
 ## Use
 
 - Using Postman or building an integration, send a request using "http://localhost:<port>/address/request"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\.tsx?$": ["ts-jest",{}],
+  },
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,13 +28,13 @@ app.use(async (req, res: Response, next: NextFunction) => {
 });
 
 app.use(async (err: any, req: Request, res: Response, next: NextFunction) => {
-    loggerService.error({ message: err.message, path: req.path }).flush();
-    res.status(500).send({
-        error: {
-            status: 500,
-            message: "Internal Error",
-        }
-    });
+  loggerService.error({ message: err.message, path: req.path }).flush();
+  res.status(err.status || 500).send({
+    error: {
+      status: err.status || 500,
+      message: err.message || "Internal Error",
+    },
+  });
 });
 
 export default app;

--- a/src/endpoints/address.endpoint.ts
+++ b/src/endpoints/address.endpoint.ts
@@ -10,6 +10,10 @@ class AddressEndpoint extends baseEndpoint {
         super.executeSubRoute(addressEndpoint, req, res, next);
     }
 
+    public get(req: Request, res: Response, next: NextFunction) {
+        super.executeSubRoute(addressEndpoint, req, res, next);
+    }
+
     private count_post(req: Request, res: Response, next: NextFunction) {
         addressService.count(req)
             .then((response) => {
@@ -42,6 +46,15 @@ class AddressEndpoint extends baseEndpoint {
             })
             .catch((err) => {
                 res.status(500).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, { error: err.message }));
+            })
+    }
+    
+    private distance_post(req: Request, res: Response, next: NextFunction) {
+        addressService.distance(req)
+            .then((response) => {
+                res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, response));
+            }).catch((err) => {
+                res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
             });
     }
 }
@@ -52,5 +65,6 @@ const getRoute = addressEndpoint.get;
 const postRoute = addressEndpoint.post;
 const putRoute = addressEndpoint.put;
 const deleteRoute = addressEndpoint.delete;
+
 
 export { getRoute, postRoute, putRoute, deleteRoute };

--- a/src/endpoints/address.endpoint.ts
+++ b/src/endpoints/address.endpoint.ts
@@ -27,6 +27,23 @@ class AddressEndpoint extends baseEndpoint {
                 res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
             });
     }
+
+    private zipcode_post(req: Request, res: Response, next: NextFunction) {
+        const { zipcode } = req.body;
+    
+        if (!zipcode) {
+            res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, { error: "Zip code is required." }));
+            return;
+        }
+    
+        addressService.getCityByZip(zipcode)
+            .then((response) => {
+                res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, { city: response }));
+            })
+            .catch((err) => {
+                res.status(500).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, { error: err.message }));
+            });
+    }
 }
 
 const addressEndpoint = new AddressEndpoint();

--- a/src/endpoints/base.endpoint.ts
+++ b/src/endpoints/base.endpoint.ts
@@ -34,6 +34,7 @@ class BaseEndpoint {
 
         const temp = endPointMethod[subRoute as keyof typeof endPointMethod];
         if (!temp) {
+            console.log(`Invalid request: ${req.originalUrl}`);
             throw new createHttpError.BadRequest();
         }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -21,6 +21,10 @@ router.delete('*', (req: Request, res: Response, next: NextFunction) => {
     (require(getEndpointControllerPath(req))).deleteRoute(req, res, next);
 });
 
+router.post('/address/zipcode', (req: Request, res: Response, next: NextFunction) => {
+    (require(getEndpointControllerPath(req))).postRoute(req, res, next);
+});
+
 function getEndpointControllerPath(req: Request): string {
     const paths = req.baseUrl.split('/');
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -27,7 +27,7 @@ function getEndpointControllerPath(req: Request): string {
     const ext = (ENV === 'dev') ? 'ts' : 'js';
     const route = `${__dirname}/endpoints/${paths[1]}.endpoint.${ext}`;
     if (paths.length === 1 || !fs.existsSync(route) || paths[1] == 'base') {
-        throw new createHttpError.BadRequest();
+        throw new createHttpError.NotFound(`Endpoint ${req.originalUrl} not found`);
     }
 
     return route;

--- a/src/router.ts
+++ b/src/router.ts
@@ -33,7 +33,7 @@ function getEndpointControllerPath(req: Request): string {
     if (paths.length === 1 || !fs.existsSync(route) || paths[1] == 'base') {
         throw new createHttpError.NotFound(`Endpoint ${req.originalUrl} not found`);
     }
-
+    console.log(route);
     return route;
 }
 

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -1,3 +1,4 @@
+import { get } from "http";
 import loggerService from "./logger.service";
 
 class AddressService {
@@ -35,6 +36,11 @@ class AddressService {
         });
     }
 
+    /**
+     * Get the city name by zip code.
+     * @param zipcode - The zip code to look up.
+     * @returns The city name associated with the provided zip code.
+     */
     public async getCityByZip(zipcode: string): Promise<string> {
         return new Promise<string>(async (resolve, reject) => {
             if (!zipcode || typeof zipcode !== "string") {
@@ -68,36 +74,180 @@ class AddressService {
         });
     }
 
+
+    /**
+     * Calculate the distance between two locations.
+     * @param addressRequest - The request object containing location1 and location2.
+     * 
+     * The body request should contain:
+     * - location1: The first location object. (Can mix and match any of the following properties)
+     * > - zipcode: The zipcode of the location.
+     * > - number: The number of the location.
+     * > - street: The street of the location.
+     * > - street2: The second street of the location.
+     * > - city: The city of the location.
+     * > - state: The state of the location.
+     * > - country: The country of the location.
+     * - location2: The second location object.
+     * > - Same properties as location1
+     * - unit: The unit of measurement for the distance (KM or Mi).
+     * 
+     * @returns The distance between the two locations in the specified unit (KM or Mi).
+     * 
+     */
     public async distance(addressRequest?: any): Promise<any> {
-        // Complete this
+
+        if (addressRequest.body) {
+            try {
+                let location1 = addressRequest.body.location1;
+                let location2 = addressRequest.body.location2;
+
+                // Check if both locations are provided
+                if (!location1 || !location2) {
+                    const errMessage = "Please provide both locations.";
+                    loggerService.error({ path: "/address/distance", message: errMessage }).flush();
+                    return { error: errMessage };
+                }
+
+                // Check if the locations are valid
+                const requiredProperties = [
+                    "zipcode", "number", "street", "street2", 
+                    "city", "state", "country"
+                ];
+
+                const hasRequiredProperties = (location: any) => 
+                    requiredProperties.some(prop => location.hasOwnProperty(prop));
+
+                if (
+                    typeof location1 !== "object" || 
+                    typeof location2 !== "object" || 
+                    !hasRequiredProperties(location1) || 
+                    !hasRequiredProperties(location2)
+                ) {
+                    const errMessage = "Invalid locations. Please ensure both locations have at least one required property. Required properties: " + requiredProperties.join(", ");
+                    loggerService.error({ path: "/address/distance", message: errMessage }).flush();
+                    return { error: errMessage };
+                }
+
+                location1 = await this.request({ body:  location1  });
+                location2 = await this.request({ body:  location2  });
+
+                // Check if the locations are valid
+                if (location1.length == 0 || location2.length == 0) {
+                    const errMessage = "Invalid locations. Please ensure both locations are valid.";
+                    loggerService.error({ path: "/address/distance", message: errMessage }).flush();
+                    return { error: errMessage };
+                }
+                
+                let averageCoordinates1 = await this.calculateAverageCoordinates(location1);
+                let averageCoordinates2 = await this.calculateAverageCoordinates(location2);
+                
+
+                if (!averageCoordinates1 || !averageCoordinates2) {
+                    const errMessage = "Invalid locations. Please ensure both locations are valid."
+                    loggerService.error({ path: "/address/distance", message: errMessage }).flush();
+                    return { error: errMessage };
+                }
+
+                if (addressRequest.body.unit === "KM") {
+                    
+                    const distance = await this.getKilometerDistance(averageCoordinates1.latitude, averageCoordinates1.longitude, averageCoordinates2.latitude, averageCoordinates2.longitude);
+                    return { distance: distance };
+
+                } else if (addressRequest.body.unit === "Mi") {
+                    const distance = await this.getMilesDistance(averageCoordinates1.latitude, averageCoordinates1.longitude, averageCoordinates2.latitude, averageCoordinates2.longitude);
+                    return { distance: distance };
+
+                } else {
+                    const errMessage = "Invalid unit. Please use 'KM' or 'Mi'."
+                    loggerService.error({ path: "/address/distance", message: errMessage }).flush();
+                    return { error: errMessage };
+                }
+
+
+            } catch (err) {
+                loggerService.error({ path: "/address/distance", message: `${(err as Error).message}` }).flush();
+                return { error: (err as Error).message };
+            }
+        }
+
+        try {
+
+
+
+        } catch (err) {
+            const errorMessage = (err as Error).message;
+            loggerService.error({ path: "/address/distance", message: errorMessage }).flush();
+            return { error: errorMessage };
+        }
     }
 
-    // private async getDistance(lat1: string, lon1: string, lat2: string, lon2: string) {
-    //     // Defining this function inside of this private method means it's
-    //     // not accessible outside of it, which is perfect for encapsulation.
-    //     const toRadians = (degrees: string) => {
-    //         return degrees * (Math.PI / 180);
-    //     }
+    private async getKilometerDistance(lat1: number, lon1: number, lat2: number, lon2: number) {
+        // Defining this function inside of this private method means it's
+        // not accessible outside of it, which is perfect for encapsulation.
+        const toRadians = (degrees: number) => {
+            return degrees * (Math.PI / 180);
+        }
 
-    //     // Radius of the Earth in KM
-    //     const R = 6371;
+        // Radius of the Earth in KM
+        const R = 6371;
 
-    //     // Convert Lat and Longs to Radians
-    //     const dLat = toRadians(lat2 - lat1);
-    //     const dLon = toRadians(lon2 - lon1);
+        // Convert Lat and Longs to Radians
+        const dLat = toRadians(lat2 - lat1);
+        const dLon = toRadians(lon2 - lon1);
 
-    //     // Haversine Formula to calculate the distance between two locations
-    //     // on a sphere.
-    //     const a =
-    //         Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    //         Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
-    //         Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        // Haversine Formula to calculate the distance between two locations
+        // on a sphere.
+        const a =
+            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+             Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+            Math.sin(dLon / 2) * Math.sin(dLon / 2);
 
-    //     const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+             // convert and return distance in KM
+            return (R * c);
+    }
 
-    //     // convert and return distance in KM
-    //     return R * c;
-    // }
+    private async getMilesDistance(lat1: number, lon1: number, lat2: number, lon2: number) {
+        const kilometers = await this.getKilometerDistance(lat1, lon1, lat2, lon2);
+        const milesPerKilometer = 0.621371;
+        return (kilometers * milesPerKilometer);
+    }
+
+    private async calculateAverageCoordinates(location: any) {
+        if (!location || !Array.isArray(location) || location.length === 0) {
+            const errMessage = "Invalid location data. Please provide a valid array of locations.";
+            loggerService.error({ path: "/address/calculateAverageCoordinates", message: errMessage }).flush();
+            throw new Error(errMessage);
+        }
+
+        const totalCoordinates = location.reduce(
+            (totals, loc) => {
+            const latitude = parseFloat(loc.latitude);
+            const longitude = parseFloat(loc.longitude);
+
+            if (isNaN(latitude) || isNaN(longitude)) {
+                const errMessage = "Invalid latitude or longitude in location data.";
+                loggerService.error({ path: "/address/calculateAverageCoordinates", message: errMessage }).flush();
+                throw new Error(errMessage);
+            }
+
+            totals.latitude += latitude;
+            totals.longitude += longitude;
+            return totals;
+            },
+            { latitude: 0, longitude: 0 }
+        );
+
+        const averageCoordinates = {
+            latitude: totalCoordinates.latitude / location.length,
+            longitude: totalCoordinates.longitude / location.length
+        };
+
+        return averageCoordinates;
+    }
+
+
 }
 
 export default new AddressService();

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -35,6 +35,39 @@ class AddressService {
         });
     }
 
+    public async getCityByZip(zipcode: string): Promise<string> {
+        return new Promise<string>(async (resolve, reject) => {
+            if (!zipcode || typeof zipcode !== "string") {
+                reject(new Error("Invalid zip code provided."));
+                return;
+            }
+    
+            fetch(AddressService.fetchUrl, {
+                method: "POST",
+                body: JSON.stringify({ zipcode }),
+                headers: { "Content-Type": "application/json" }
+            })
+                .then(async (response) => {
+                    if (!response.ok) {
+                        reject(new Error("Failed to fetch city for the provided zip code."));
+                        return;
+                    }
+    
+                    const data = await response.json() as { city: string }[];
+                    if (data.length === 0) {
+                        reject(new Error("No city found for the provided zip code."));
+                        return;
+                    }
+    
+                    resolve(data[0].city); // Assuming the API returns an array of results
+                })
+                .catch((err) => {
+                    loggerService.error({ path: "/address/getCityByZip", message: err.message }).flush();
+                    reject(err);
+                });
+        });
+    }
+
     public async distance(addressRequest?: any): Promise<any> {
         // Complete this
     }

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -10,7 +10,7 @@ class AddressService {
             this.request(addressRequest)
                 .then((response) => {
                     resolve({
-                        "count": response.size()
+                        "count": response.length
                     });
                 })
                 .catch((err) => {

--- a/src/tests/address.service.distance.test.ts
+++ b/src/tests/address.service.distance.test.ts
@@ -1,0 +1,184 @@
+import addressService from "../services/address.service";
+
+describe("Address Service", () => {
+    it("Return distance in Kilometers", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY"
+            
+                },
+                "location2": {
+                    "state":"AK"
+            
+                },
+                "unit": "Mi"
+            
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("distance", expect.any(Number));
+    });
+
+    it("Return distance in Miles", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY"
+            
+                },
+                "location2": {
+                    "state":"AK"
+            
+                },
+                "unit": "Mi"
+            
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("distance", expect.any(Number));
+    });
+
+    it("Expecting the distance to be 56.2786811179502 Mi", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "Rochester"
+            
+                },
+                "location2": {
+                    "state":"NY",
+                    "city":"Buffalo"
+            
+                },
+                "unit": "Mi"
+            
+            }
+        };
+
+        const expectedDistance = 56.2786811179502; 
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("distance", expectedDistance);
+    });
+
+    it("Expecting the distance to be 90.57178580582325 Mi", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "Rochester"
+            
+                },
+                "location2": {
+                    "state":"NY",
+                    "city":"Buffalo"
+            
+                },
+                "unit": "KM"
+            
+            }
+        };
+
+        const expectedDistance = 90.57178580582325; 
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("distance", expectedDistance);
+    });
+
+    it("Throw exception if unit is blank", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "Rochester"
+            
+                },
+                "location2": {
+                    "state":"NY",
+                    "city":"Buffalo"
+            
+                },
+                "unit": ""
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("error", "Invalid unit. Please use 'KM' or 'Mi'.");
+    });
+
+    it("Throw exception if location 2 is missing", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "Rochester"
+            
+                },
+
+                "unit": "Mi"
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("error", "Please provide both locations.");
+    });
+
+    it("Throw exception if locations are not valid objects", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "Rochester"
+            
+                },
+                "location2": "test"
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("error", "Invalid locations. Please ensure both locations have at least one required property. Required properties: zipcode, number, street, street2, city, state, country");
+    });
+
+    it("Throw exception if a required property is missing in location1", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "bagel": "Rochester"
+                },
+                "location2": {
+                    "state": "NY",
+                    "city": "Buffalo"
+                },
+                "unit": "Mi"
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("error", "Invalid locations. Please ensure both locations have at least one required property. Required properties: zipcode, number, street, street2, city, state, country");
+    });
+
+    it("Throw exception if a city does not exist", async () => {
+        const addressRequest = {
+            body: {
+                "location1": {
+                    "state": "NY",
+                    "city": "NonExistentCity"
+                },
+                "location2": {
+                    "state": "NY",
+                    "city": "Buffalo"
+                },
+                "unit": "Mi"
+            }
+        };
+
+        const response = await addressService.distance(addressRequest);
+        expect(response).toHaveProperty("error", "Invalid locations. Please ensure both locations are valid.");
+    });
+
+
+});

--- a/src/tests/address.service.zipcode.test.ts
+++ b/src/tests/address.service.zipcode.test.ts
@@ -1,0 +1,31 @@
+import addressService from "../services/address.service";
+
+describe("Address Service - Zip Code", () => {
+    it("should return city name for a valid zip code", async () => {
+        const zipcode = "14623";
+
+        const response = await addressService.getCityByZip(zipcode);
+
+        expect(response).toBeDefined();
+        expect(typeof response).toBe("string");
+        expect(response).toBe("ROCHESTER"); // Replace with the expected city for the zip code
+    }, 60000); // 60 seconds timeout
+
+    it("should throw an error for missing zip code", async () => {
+        const zipcode = "";
+
+        await expect(addressService.getCityByZip(zipcode)).rejects.toThrow("Invalid zip code provided.");
+    }, 60000); // 60 seconds timeout
+
+    it("should throw an error for invalid zip code", async () => {
+        const zipcode = "00000";
+
+        await expect(addressService.getCityByZip(zipcode)).rejects.toThrow("No city found for the provided zip code.");
+    }, 60000); // 60 seconds timeout
+
+    it("should throw an error if zip code is not a string", async () => {
+        const zipcode = 12345 as unknown as string; // Simulate invalid type
+
+        await expect(addressService.getCityByZip(zipcode)).rejects.toThrow("Invalid zip code provided.");
+    }, 60000); // 60 seconds timeout
+});


### PR DESCRIPTION
This pull request introduces a new endpoint that accepts in a request with a zip code and responds with the city name that the zip code is associated with. 

### New Features:
* Added `zipcode_post` method to `AddressEndpoint` to handle requests for city names by zip code.
* Implemented `getCityByZip` method in `AddressService` to fetch city names by zip code.


### Tests:
* Added tests for `getCityByZip` method in `address.service.zipcode.test.ts` to validate city name retrieval and error scenarios.